### PR TITLE
add unit tests for Report model.  begin adding unit tests for celery …

### DIFF
--- a/teamreporter/tasks.py
+++ b/teamreporter/tasks.py
@@ -29,7 +29,6 @@ def send_survey(survey_pk):
 
     survey.user.email_user(subject, text_content, settings.DEFAULT_FROM_EMAIL, html_message=html_content)
 
-
 @app.task
 def generate_survey(user_pk, daily_pk):
     user = User.objects.get(pk=user_pk)

--- a/teamreporter/test_models.py
+++ b/teamreporter/test_models.py
@@ -1,0 +1,68 @@
+from unittest.mock import MagicMock
+from django.test import TestCase
+from .models import Report, User, Team
+from datetime import time, datetime, timedelta
+import recurrence
+
+class TestReport(TestCase):
+    def setUp(self):
+        curr_day = datetime.today().weekday()
+        all_days = list(range(7))
+        all_days_but_today = list(range(7))
+        all_days_but_today.remove(curr_day)
+        rule = recurrence.Rule(recurrence.WEEKLY, byday=all_days)
+        rule_not = recurrence.Rule(recurrence.WEEKLY, byday=all_days_but_today)
+        rec = recurrence.Recurrence(rrules = [rule])
+        rec_not = recurrence.Recurrence(rrules = [rule_not])
+        self.admin = User.objects.create(email="celery@admin.com", username="celery_admin")
+        self.team = Team.objects.create(name = "celery_team_test", admin=self.admin)
+        self.report = Report.objects.create(team = self.team, recurrences = rec, survey_send_time=time.min)
+        self.report_not_today = Report.objects.create(team = self.team, recurrences = rec_not, survey_send_time=time.min)
+
+    def test_occurs_today(self):
+        """
+        Tests occurs_today property
+        Decides whether or not a daily report should be created for today
+        """
+
+        self.assertTrue(self.report.occurs_today)
+        self.assertFalse(self.report_not_today.occurs_today)
+
+    def test_can_issue_daily(self):
+        """
+        Tests can_issue_daily method
+        Decides if the daily report surveys can be sent out or not
+        """
+
+        self.assertTrue(self.report.can_issue_daily())  #if daily report isn't issued, should be True
+        self.report.survey_send_time = time.max
+        self.assertFalse(self.report.can_issue_daily()) #if hour is later than current time, don't issue
+        self.report.survey_send_time = time.min
+        self.report.get_daily() #create daily report
+        self.assertFalse(self.report.can_issue_daily()) #assumed after daily report is created the daily report has already been sent
+
+    def test_get_daily(self):
+        """
+        Tests get_daily method
+        Grabs the report instance for a particular day.  Unique for day/report
+        """
+
+        first = self.report.get_daily()
+        second = self.report.get_daily()
+        self.assertTrue(first == second) #ensures the same daily report was grabbed from the DB and a new one wasn't created
+        self.assertTrue(second) #just ensures its not returning None
+
+    def test_can_issue_summary(self):
+        """
+        Tests can_issue_summary
+        Decides if summary for daily report can be sent out or not based on if it already has and if the daily report has been created
+        """
+
+        daily = self.report.get_daily()
+        daily.delete()
+        self.assertFalse(self.report.can_issue_summary()) # daily report hasn't been created yet, summary should not be submitted
+        daily = self.report.get_daily()
+        self.assertTrue(self.report.can_issue_summary()) # daily report created but summary hasn't been submitted.  Should be allowed
+        daily.summary_submitted = datetime.now()
+        daily.save()
+        self.assertFalse(self.report.can_issue_summary()) # daily report created and summary been submitted.  No more summaries should be allowed

--- a/teamreporter/test_tasks.py
+++ b/teamreporter/test_tasks.py
@@ -34,11 +34,14 @@ class TestTasks(TestCase):
         Survey should be created if daily report exists/is valid and the user the survey is going to is actually on the team
         """
 
-        result = generate_survey(self.user.id, self.report.get_daily()).get()  # should create a survey given a valid daily report and user on the team
+        result = generate_survey.apply((self.user.id, self.report.get_daily().id)).get()  # should create a survey given a valid daily report and user on the team
         self.assertTrue(result)
 
-        result = generate_survey(3, self.report.get_daily()).get()  # User is not on this team therefore survey shouldn't be created
+        result = generate_survey.apply((self.admin.id, self.report.get_daily().id)).get()  # User is not on this team therefore survey shouldn't be created
         self.assertFalse(result)
+
+        #result = generate_survey.apply((3, self.report.get_daily().id)).get()  # User doesn't exist, not sure what we want here
+        #self.assertFalse(result)
 
     def test_issue_survey(self):
         """

--- a/teamreporter/test_tasks.py
+++ b/teamreporter/test_tasks.py
@@ -42,7 +42,10 @@ class TestTasks(TestCase):
 
     def test_issue_survey(self):
         """
-        test survey issuing
+        Test survey issuing
+        TODO: test multiple users
+
+        Returns the number of users a survey was sent to.  TODO: issue_survey can probably return something with more info in the future
         """
         result = issue_surveys.apply().get()
         self.assertTrue(result == 1)
@@ -53,3 +56,10 @@ class TestTasks(TestCase):
 
     def test_send_survey(self):
         pass
+
+    def test_send_summary(self):
+        pass
+
+    def test_issue_summaries(self):
+        pass
+

--- a/teamreporter/test_tasks.py
+++ b/teamreporter/test_tasks.py
@@ -1,7 +1,34 @@
 from .tasks import send_survey, generate_survey, send_summary, issue_summaries, issue_surveys
-from unittest.mock import Mock
+from unittest.mock import MagicMock
+from django.test.utils import override_settings
 from django.test import Client, TestCase
+from .models import Report, Team, Membership, User, Survey, Role
+import recurrence
+from datetime import time
 
 class TestTasks(TestCase):
-	def setUp(self):
-		pass
+    fixtures = ["teamreporter/fixtures/roles.json"]
+
+    @override_settings(CELERY_EAGER_PROPAGATES_EXCEPTIONS=True,
+                       CELERY_ALWAYS_EAGER=True,
+                       BROKER_BACKEND='memory')
+
+    def setUp(self):
+        rule = recurrence.Rule(recurrence.WEEKLY, byday = list(range(7)))
+        rec = recurrence.Recurrence(rrules = [rule])
+        self.admin = User.objects.create(email="celery@admin.com", username="celery_admin")
+        self.user = User.objects.create(email="celery@user.com", username="celery_user")
+        self.team = Team.objects.create(name = "celery_team_test", admin=self.admin)
+        roles = Role.objects.all()
+        self.membership = Membership.objects.create(user=self.user, team = self.team)
+        for r in roles:
+            self.membership.roles.add(r)
+
+        self.team.membership_set.add(self.membership)
+        self.report = Report.objects.create(team = self.team, recurrences = rec, survey_send_time=time(0, 0))
+        self.report.can_issue_daily = MagicMock(return_value = True)
+
+    def test_issue_survey(self):
+        """test survey issuing"""
+        result = issue_surveys.apply().get()
+        self.assertTrue(result == 1)


### PR DESCRIPTION
Can create a fixture for these tests later but I just wanted to document/test the functionality of the methods on Report that relate to scheduling.  One thing we might want to consider changing is the can_issue_daily functionality.  In the test you can see once a daily_report has been created, this method says you're not allowed to issue the daily surveys/report again (if the method is called again).  The problem here is if something goes wrong in the middle of the Celery task the results will be incomplete but we won't know it.
